### PR TITLE
One more fix in the CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 0.0.2
+cff-version: 1.2.0
 message: "If you use this cookbook, please cite it as below."
 authors:
   - family-names: Khider


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Still working through the bugs getting this cookbook listed on the gallery.

I think I've sorted it out now. There was an error in the cff version number that was unrecognized by the cff parser. This PR fixes that. I've verified that the cffconvert parser is now able to interpret the CITATION.cff file locally with this fix, so the gallery rendering should "just work" after this PR is merged.