### PR TITLE
Add cook-off event tag

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -7,3 +7,5 @@ tags:
     - Pyleoclim
     - xarray
     - eofs
+  events:
+    - Cook-off 2024


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
I'm using this cookbook repo as a test of a new gallery tag for events, so we can make dynamic collections of cookbooks associated with particular hackathons.

This PR adds the "Cook-off 2024" tag. It will have no effect on the cookbook itself, just how it is displayed in the Pythia gallery.